### PR TITLE
Pre 2025-04-01 SPA fix

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -9,9 +9,9 @@ const app = new Hono<{
 .get('/test', (c) => {
 	return c.text('Hello World!');
 })
-// .notFound((c) => {
-// 	return c.newResponse(null, { status: 404 });
-// });
+.notFound((c) => {
+	return c.env.ASSETS.fetch(c.req.raw)
+});
 
 
 export type AppType = typeof app;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,7 +16,7 @@
 	},
 	"assets": {
 		"not_found_handling": "single-page-application",
-		"directory": "./dist"
+		"binding": "ASSETS"
 	},
 	"observability": {
 		"enabled": true


### PR DESCRIPTION
When not using the `assets_navigation_prefers_asset_serving` compatibility flag, you need to manually pass through fallback requests to asset serving.

Additionally, the asset directory is not `./dist`, but `./dist/client`. Our Vite plugin sets this automatically for you, so you don't need to specify it yourself.